### PR TITLE
Ahoy version of browser gem is outdated and thrwoing error

### DIFF
--- a/ahoy_matey.gemspec
+++ b/ahoy_matey.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails"
   spec.add_dependency "addressable"
-  spec.add_dependency "browser", ">= 0.4.0"
+  spec.add_dependency "browser", "~> 1.1"
   spec.add_dependency "geocoder"
   spec.add_dependency "referer-parser", ">= 0.3.0"
   spec.add_dependency "user_agent_parser"


### PR DESCRIPTION
Ahoy version of browser gem is outdated and throwing error

https://github.com/fnando/browser/issues/210
https://github.com/ankane/ahoy/issues/146
